### PR TITLE
ECS

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -15,7 +15,7 @@
  {<<"jsone">>,{pkg,<<"jsone">>,<<"1.7.0">>},1},
  {<<"overworld">>,
   {git,"https://github.com/saltysystems/overworld.git",
-       {ref,"12d2caeb5216970a73a8d563bc1cce0c5d2aa4e2"}},
+       {ref,"48ed9d13de45957a5c793aef479044a88588178b"}},
   0},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.8.0">>},2}]}.
 [

--- a/src/ks_actor.erl
+++ b/src/ks_actor.erl
@@ -32,6 +32,7 @@ new(Handle, ID, World) ->
             max_vel => 400
         },
     Latency = 0,
+    Reactor = {0, 100, 5},
     Query = ow_ecs:query(World),
     ow_ecs:add_component(actor, true, ID, Query),
     ow_ecs:add_component(handle, Handle, ID, Query),
@@ -40,6 +41,7 @@ new(Handle, ID, World) ->
     ow_ecs:add_component(hitbox, Hitbox, ID, Query),
     ow_ecs:add_component(stats, Stats, ID, Query),
     ow_ecs:add_component(latency, Latency, ID, Query),
+    ow_ecs:add_component(reactor, Reactor, ID, Query),
     % Always get the actor back from the ETS table
     ow_ecs:entity(ID, Query).
 

--- a/src/ks_input.erl
+++ b/src/ks_input.erl
@@ -18,7 +18,8 @@ apply([Input | Rest], ID, Actions, Query) ->
                 {KeyPress, Fun} ->
                     Fun(ID, Cursor, Query);
                 false ->
-                    ok % maybe an input not for us
+                    % maybe an input not for us
+                    ok
             end
         end,
     lists:foreach(Apply, KeyList),

--- a/src/ks_phys.erl
+++ b/src/ks_phys.erl
@@ -27,7 +27,7 @@ key_table() ->
     ].
 
 -spec proc_phys(ow_ecs:query(), term()) -> ok.
-proc_phys(Query, #{ tick_ms := TickMs }) ->
+proc_phys(Query, #{tick_ms := TickMs}) ->
     % Match the input and components for any changes this tick
     Actors = ow_ecs:match_components([input, phys], Query),
     % Apply the input for any player who has the input component, then zero out

--- a/src/ks_reactor.erl
+++ b/src/ks_reactor.erl
@@ -1,0 +1,29 @@
+-module(ks_reactor).
+% Ship's reactor. Energy is drained every time a fire is shot, then recharges.
+
+-export([proc_reactor/2]).
+
+proc_reactor(Query, _ZoneData) ->
+    % Match any entities who have input this tick
+    Fun = 
+        fun(ID, ComponentValue) ->
+            {Cur, Max, R} = ComponentValue,
+            logger:notice("Reactor charge: ~p", [Cur]),
+            Cur1 = 
+            if 
+                Cur < Max -> 
+                    % Recharge the reactor
+                    Cur + R;
+                true ->
+                    % Set the reactor to max
+                    Max
+            end,
+            if 
+                Cur =/= Max ->
+                    % Changed, so update the table
+                    ow_ecs:add_component(reactor, {Cur1, Max, R}, ID, Query);
+                true ->
+                    ok
+            end
+        end,
+    ow_ecs:foreach_component(Fun, reactor, Query).

--- a/src/ks_reactor.erl
+++ b/src/ks_reactor.erl
@@ -5,20 +5,20 @@
 
 proc_reactor(Query, _ZoneData) ->
     % Match any entities who have input this tick
-    Fun = 
+    Fun =
         fun(ID, ComponentValue) ->
             {Cur, Max, R} = ComponentValue,
             logger:notice("Reactor charge: ~p", [Cur]),
-            Cur1 = 
-            if 
-                Cur < Max -> 
-                    % Recharge the reactor
-                    Cur + R;
-                true ->
-                    % Set the reactor to max
-                    Max
-            end,
-            if 
+            Cur1 =
+                if
+                    Cur < Max ->
+                        % Recharge the reactor
+                        Cur + R;
+                    true ->
+                        % Set the reactor to max
+                        Max
+                end,
+            if
                 Cur =/= Max ->
                     % Changed, so update the table
                     ow_ecs:add_component(reactor, {Cur1, Max, R}, ID, Query);

--- a/src/ks_zone2.erl
+++ b/src/ks_zone2.erl
@@ -152,6 +152,7 @@ init([]) ->
     Query = ow_ecs:query(World),
     % Add the systems
     ow_ecs:add_system({ks_phys, proc_phys, 2}, 200, Query),
+    ow_ecs:add_system({ks_reactor, proc_reactor, 2}, 900, Query),
     ow_ecs:add_system({ks_projectile, proc_projectile, 1}, 100, Query),
     ow_ecs:add_system({ks_collision, proc_collision, 2}, 300, Query),
     ow_ecs:add_system({ks_input, proc_reset, 1}, 900, Query),

--- a/src/ks_zone2.erl
+++ b/src/ks_zone2.erl
@@ -212,7 +212,7 @@ handle_tick(TickMs, State = #{ecs_world := World}) ->
     %#{gamestate_buffer := [ Snapshot | GSBuf ]} = State1,
     % Call systems, feed in relevant zone data if necessary
     ZoneData = maps:with([boundary], State),
-    ow_ecs:proc(World, ZoneData#{ tick_ms => TickMs }),
+    ow_ecs:proc(World, ZoneData#{tick_ms => TickMs}),
     ToXfer = #{
         phys_updates => get_actor_phys(World),
         projectiles => ks_projectile:notify(World),


### PR DESCRIPTION
This is a major overhaul that does a full conversion to Entity Component System (ECS) as shipped in Overworld.

At zone startup, there's a number of systems that get added to the zone. E.g.:
```erlang
    ow_ecs:add_system({ks_phys, proc_phys, 2}, 200, Query),
    ow_ecs:add_system({ks_reactor, proc_reactor, 2}, 900, Query),
    ow_ecs:add_system({ks_projectile, proc_projectile, 1}, 100, Query),
    ow_ecs:add_system({ks_collision, proc_collision, 2}, 300, Query),
    ow_ecs:add_system({ks_input, proc_reset, 1}, 900, Query),
```

These are various subsystems for players and objects, such as Physics, Projectile Creation, Collision, Input handlers, etc.

Then entities in the zone have various components added to them when they're instanced. E.g. for a Actor (player):
```erlang
    ow_ecs:add_component(actor, true, ID, Query),
    ow_ecs:add_component(handle, Handle, ID, Query),
    ow_ecs:add_component(type, Type, ID, Query),
    ow_ecs:add_component(phys, Phys, ID, Query),
    ow_ecs:add_component(hitbox, Hitbox, ID, Query),
    ow_ecs:add_component(stats, Stats, ID, Query),
    ow_ecs:add_component(latency, Latency, ID, Query),
    ow_ecs:add_component(reactor, Reactor, ID, Query),
```

Every tick, ECS will return an entity that matches some query. For Physics, for example, we look for anything that has had input and physics, and apply the input. Then we look for anything that has the physics property, and update its position this tick. 
```erlang
-spec proc_phys(ow_ecs:query(), term()) -> ok.
proc_phys(Query, #{tick_ms := TickMs}) ->
    % Match the input and components for any changes this tick
    Actors = ow_ecs:match_components([input, phys], Query),
    % Apply the input for any player who has the input component, then zero out
    % the component.
    process_actors(Actors, Query),
    % Update positions, including non-actors
    PhysEntities = ow_ecs:match_component(phys, Query),
    update_positions(PhysEntities, TickMs, Query).
```

Everything has been re-implemented in ECS mode, and I've also added a simple "reactor" system that doesn't let actors fire streams of bullets as fast as they can send input over the network. If an entity tries to shoot, it subtracts a some "power" from the reactor system. The power regenerates a little bit every tick. Just as SubSpace.